### PR TITLE
Set revalidation interval to 60 seconds for pages

### DIFF
--- a/src/app/guestbook/page.tsx
+++ b/src/app/guestbook/page.tsx
@@ -5,6 +5,8 @@ import prisma from '@/lib/prisma';
 import GuestbookList from '@/features/guestbook/components/guestbook-list';
 import Link from 'next/link';
 
+export const revalidate = 60;
+
 export default async function GuestbookPage() {
   const guestbook = await prisma.guestbook.findMany({
     orderBy: { id: 'desc' },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,8 @@ import Location from '@/features/location/components/location';
 import Photos from '@/features/photos/components/photos';
 import Guestbook from '@/features/guestbook/components/guestbook';
 
+export const revalidate = 60;
+
 export default function Home() {
   return (
     <div>


### PR DESCRIPTION
Added `revalidate = 60` to the Home and Guestbook pages to enable ISR (Incremental Static Regeneration). This ensures the pages refresh with new data every 60 seconds for improved user experience while maintaining performance.